### PR TITLE
chore: improve Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,7 @@
     },
     {
       "description": "Require manual review for native dependency updates",
-      "matchManagers": [
-        "bundler",
-        "cocoapods",
-        "gradle",
-        "gradle-wrapper"
-      ],
+      "matchManagers": ["bundler", "cocoapods", "gradle", "gradle-wrapper"],
       "automerge": false
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["npm", "github-actions"],
+  "extends": ["config:best-practices", ":automergeStableNonMajor"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "description": "Group React Native ecosystem updates for manual review",
+      "groupName": "React Native ecosystem",
+      "matchPackageNames": [
+        "react",
+        "react-native",
+        "@types/react",
+        "@react-native/**",
+        "@react-native-community/**"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Require manual review for native dependency updates",
+      "matchManagers": [
+        "bundler",
+        "cocoapods",
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- adopt the official config:best-practices preset
- delay npm updates to avoid Yarn age-gate failures
- enable automatic detection of native and runtime managers
- automerge only stable non-major dependencies
- group React Native ecosystem updates for manual review
- require manual review for Bundler, CocoaPods, Gradle, and Gradle Wrapper updates

## Validation

- Renovate 44.50.1 strict configuration validation
- JSON diff check